### PR TITLE
Image loading performance improvement.

### DIFF
--- a/CombineAssets/App.config
+++ b/CombineAssets/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    </startup>
+</configuration>

--- a/CombineAssets/CombineAssets.csproj
+++ b/CombineAssets/CombineAssets.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{237FC7CF-BCB2-48D4-B863-AE7E32297EB8}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>CombineAssets</RootNamespace>
+    <AssemblyName>CombineAssets</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DirElement.cs" />
+    <Compile Include="Element.cs" />
+    <Compile Include="FileElement.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utils.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/CombineAssets/DirElement.cs
+++ b/CombineAssets/DirElement.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace CombineAssets
+{
+    public class DirElement : Element
+    {
+        public DirElement(string path, string root)
+            : base(path)
+        {
+            Name = new DirectoryInfo(path).Name;
+            Location = path.Substring(new DirectoryInfo(root).FullName.Length);
+
+            if (Location.StartsWith("\\"))
+                Location = Location.Substring(1);
+
+            if (string.IsNullOrWhiteSpace(Location))
+                Location = @"\";
+
+            Location = Location.Replace('\\', '/');
+            PopulateChildren(path, root);
+        }
+
+        private void PopulateChildren(string path, string root)
+        {
+            _children.Clear();
+
+            List<FileElement> files = Directory
+                .EnumerateFiles(path)
+                .Where(Utils.IsImage)
+                .Select(filePath => new FileElement(filePath))
+                .ToList();
+
+            files.Sort(new FileComparer());
+
+            _children.AddRange(files);
+
+            IEnumerable<DirElement> dirs = Directory
+                .EnumerateDirectories(path)
+                .OrderBy(f => f)
+                .Select(folder => new DirElement(folder, root));
+
+            _children.AddRange(dirs);
+        }
+
+        private class FileComparer : IComparer<FileElement>
+        {
+            public int Compare(FileElement x, FileElement y)
+            {
+                int nameCompare = x.Name.CompareTo(y.Name);
+
+                return nameCompare != 0
+                    ? nameCompare
+                    : x.Index.GetValueOrDefault().CompareTo(y.Index.GetValueOrDefault());
+            }
+        }
+    }
+}

--- a/CombineAssets/Element.cs
+++ b/CombineAssets/Element.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+namespace CombineAssets
+{
+    public abstract class Element
+    {
+        protected Element(string path)
+        {
+            ElementPath = path;
+            _children = new List<Element>();
+        }
+
+        public string ElementPath { get; }
+        public string Name { get; set; }
+        protected List<Element> _children;
+        public IReadOnlyList<Element> Children => _children;
+        public string Location { get; set; }
+    }
+}

--- a/CombineAssets/FileElement.cs
+++ b/CombineAssets/FileElement.cs
@@ -1,0 +1,23 @@
+﻿using System.IO;
+using System.Text.RegularExpressions;
+
+namespace CombineAssets
+{
+    public class FileElement : Element
+    {
+        public FileElement(string path)
+            : base(path)
+        {
+            string fullName = Path.GetFileNameWithoutExtension(path);
+            Location = Path.GetDirectoryName(path);
+
+            var groups = Regex.Match(fullName, @"^(.+?)(\d*)$").Groups;
+            Name = groups[1].Value;
+
+            if (!string.IsNullOrWhiteSpace(groups[2].Value))
+                Index = int.Parse(groups[2].Value);
+        }
+
+        public int? Index { get; set; }
+    }
+}

--- a/CombineAssets/Program.cs
+++ b/CombineAssets/Program.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace CombineAssets
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 1)
+            {
+                Console.WriteLine("USAGE:");
+                Console.WriteLine("       CombineAssets path [rootPath]");
+                return;
+            }
+
+            string dir = args[0];
+            string rootPath = args.Length > 1 ? args[1] : "";
+            WriteAssets(dir, rootPath);
+        }
+
+        private static string CalcIndent(int level) => new String(' ', level * 2);
+
+        private static string GetFileText(FileElement file, int level)
+        {
+            string indent = CalcIndent(level);
+            string extension = Path.GetExtension(file.ElementPath).Substring(1);
+            string data = Convert.ToBase64String(File.ReadAllBytes(file.ElementPath));
+            return $@"{indent}""data:image/{extension};base64,{data}""";
+        }
+
+        private static string GetDirText(DirElement dir, int level)
+        {
+            string indent = CalcIndent(level++);
+            string indent2 = CalcIndent(level++);
+            var sb = new StringBuilder();
+            sb.AppendLine($"{indent}{{");
+
+            IEnumerable<IGrouping<string, FileElement>> groups = dir.Children
+                .OfType<FileElement>()
+                .Where(f => Utils.IsImage(f.ElementPath))
+                .GroupBy(c => c.Name);
+
+            bool first = true;
+
+            foreach (IGrouping<string, FileElement> group in groups)
+            {
+                if (!first)
+                    sb.AppendLine(",");
+
+                sb.AppendLine($@"{indent2}""{group.Key.ToLower()}"": [");
+                bool firstChild = true;
+
+                foreach (FileElement file in group)
+                {
+                    if (!firstChild)
+                        sb.AppendLine(",");
+
+                    sb.Append($"{GetFileText(file, level)}");
+                    firstChild = false;
+                }
+
+                sb.AppendLine();
+                sb.Append($"{indent2}]");
+                first = false;
+            }
+
+            sb.AppendLine();
+            sb.AppendLine($"{indent}}}");
+            return sb.ToString();
+        }
+
+        private static IEnumerable<DirElement> GetDirAndSubDir(DirElement dir)
+            => new[] { dir }.Concat(dir.Children.OfType<DirElement>().SelectMany(GetDirAndSubDir));
+
+        private static void WriteDirs(DirElement dir)
+        {
+            var filename = "images.json";
+            var filePath = Path.Combine(dir.ElementPath, filename);
+
+            using (var file = new StreamWriter(filePath, true))
+            {
+                int level = 0;
+                string indent = CalcIndent(level++);
+                string indent2 = CalcIndent(level);
+                file.WriteLine($"{indent}{{");
+                bool first = true;
+
+                IEnumerable<DirElement> subs = GetDirAndSubDir(dir)
+                    .Where(d => d.Children.OfType<FileElement>().Any(f => Utils.IsImage(f.ElementPath)));
+
+                foreach (DirElement sub in subs)
+                {
+                    if (!first)
+                        file.WriteLine(",");
+
+                    file.Write($@"{indent2}""{sub.Location.ToLower()}"": ");
+                    file.Write($"{GetDirText(sub, level).Trim()}");
+                    first = false;
+                }
+
+                file.WriteLine();
+                file.WriteLine($"{indent}}}");
+            }
+        }
+
+        private static void WriteAssets(string dir, string rootPath = "")
+        {
+            if (string.IsNullOrWhiteSpace(rootPath))
+            {
+                var folder = new DirectoryInfo(dir);
+
+                while (folder.Name.ToLower() != "wwwroot" && folder.Parent != null)
+                {
+                    folder = folder.Parent;
+                }
+
+                rootPath = folder.FullName;
+            }
+
+            var root = new DirElement(dir, rootPath);
+            WriteDirs(root);
+        }
+    }
+}

--- a/CombineAssets/Properties/AssemblyInfo.cs
+++ b/CombineAssets/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CombineAssets")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CombineAssets")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("237fc7cf-bcb2-48d4-b863-ae7e32297eb8")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/CombineAssets/Utils.cs
+++ b/CombineAssets/Utils.cs
@@ -1,0 +1,15 @@
+﻿using System.IO;
+using System.Linq;
+
+namespace CombineAssets
+{
+    public static class Utils
+    {
+        private static string[] _imageExtensions = new[] { ".png" };
+        private static string[] _audioExtensions = new[] { ".wav", ".mp3" };
+
+        public static bool IsImage(string filename) => _imageExtensions.Contains(Path.GetExtension(filename));
+        public static bool IsAudio(string filename) => _audioExtensions.Contains(Path.GetExtension(filename));
+        public static bool IsImageOrAudio(string filename) => IsImage(filename) || IsAudio(filename);
+    }
+}

--- a/OverlayManager/TS/Game Engine/Sprites.ts
+++ b/OverlayManager/TS/Game Engine/Sprites.ts
@@ -26,13 +26,14 @@
     var self = this;
     this.originX = 0;
     this.originY = 0;
-    this.baseAnimation.images[0].onload = function () {
-      self.spriteWidth = (<HTMLImageElement>this).width;
-      self.spriteHeight = (<HTMLImageElement>this).height;
+
+    this.baseAnimation.imagesLoaded.then(image => {
+      self.spriteWidth = image.width;
+      self.spriteHeight = image.height;
       self.loaded = true;
       if (onLoadedFunc != null)
         onLoadedFunc(self);
-    };
+    });
 
     this.lastTimeWeAdvancedTheFrame = performance.now();
   }


### PR DESCRIPTION
Improves image loading performance.

Run "CombineAssets [path to wwwroot]" to create a file named images.json in that folder.  This file will contain all the images for that folder and subfolders.

The Part class will now be able to make just one round trip to the server to load all images.

The ImageManager class is the one that actually does the loading.  For simplicity, I've created it as a static class but it really should be an instantiable class that is passed to Part.  This way, each game can have its own images.json file and only the file for the game would be loaded when needed.

There aren't as many audio files so I didn't include those but it's easy to modify the code to support audio if needed.

NOTE:

There are a lot of source files that are being transferred.  Using a bundler should significantly speed up that process as well.  I suspect the load time of the app would be reduced by at least 80% with both improvements.
